### PR TITLE
Добавление поддержки SNI-несовместимых клиентов Netflix-а

### DIFF
--- a/configs/etc/sniproxy.conf
+++ b/configs/etc/sniproxy.conf
@@ -35,3 +35,51 @@ table {
     radio\.com *
     streamtheworld\.com *
 }
+
+### Netflix non-SNI clients support ###
+
+# api-global.netflix.com
+listener 0.0.0.0 4431 {
+    proto tls
+    bad_requests log
+    table Netflix
+
+    access_log {
+        filename /var/log/sniproxy/sniproxy.netflix.api-global.log
+        priority debug
+    }
+
+    fallback 107.20.251.245:443
+}
+
+# uiboot.netflix.com
+listener 0.0.0.0 4432 {
+    proto tls
+    bad_requests log
+    table Netflix
+
+    access_log {
+        filename /var/log/sniproxy/sniproxy.netflix.uiboot.log
+        priority debug
+    }
+
+    fallback 54.243.255.149:443
+}
+
+# secure.netflix.com
+listener 0.0.0.0 4433 {
+    proto tls
+    bad_requests log
+    table Netflix
+
+    access_log {
+        filename /var/log/sniproxy/sniproxy.netflix.secure.log
+        priority debug
+    }
+
+    fallback 23.43.140.107:443
+}
+
+table Netflix {
+    netflix\.com *
+}

--- a/netflix_redirect.sh
+++ b/netflix_redirect.sh
@@ -20,7 +20,7 @@ I='/usr/sbin/iptables'
 IP='/usr/sbin/ip'
 
 # Mode of operation (add / remove)
-IPT_ACTION="A"
+IPT_ACTION="I"
 IP_ACTION="add"
 
 [ "x${1}" == "x--delete" ] && \

--- a/netflix_redirect.sh
+++ b/netflix_redirect.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Local interface (usually it's a bridge of wired and WiFi interfaces)
+inIF='br-lan'
+# External interface (to ISP)
+extIF='eth0.2'
+
+# Pseudo-addresses to catch non-SNI request and redirect them to upstream proxy
+# The IP-s are added to local interface
+sADDR='192.168.44.3' # 301 302 303
+sADDR_MASK='29'
+# IP-address of upstream proxy (must be inside the US)
+dADDR='107.170.15.247' # portaller.com
+
+# 'Mask' of the upsteam's port. The specific port is a concat. of the mask and the number
+dPORT0='443'
+
+# Pathes
+I='/usr/sbin/iptables'
+IP='/usr/sbin/ip'
+
+# Mode of operation (add / remove)
+IPT_ACTION="A"
+IP_ACTION="add"
+
+[ "x${1}" == "x--delete" ] && \
+	IPT_ACTION="D" && \
+	IP_ACTION="del"
+
+HOSTS="api-global.netflix.com uiboot.netflix.com secure.netflix.com"
+
+for ID in `seq 1 3`; do
+	#echo "Setting up pseudo-address ${sADDR}${ID} on ${inIF}"
+	$IP addr ${IP_ACTION} ${sADDR}${ID}/${sADDR_MASK} dev ${inIF} > /dev/null 2>&1
+
+	#echo "Configuring DNAT-redirection from the IP to ${dPORT0}${ID}"
+	$I -t nat -${IPT_ACTION} PREROUTING ! -i ${extIF} -p tcp -d ${sADDR}${ID} --dport 443 -j DNAT --to-destination ${dADDR}:${dPORT0}${ID} > /dev/null 2>&1
+
+	#echo "Configuring firewall..."
+	$I -t filter -${IPT_ACTION} FORWARD ! -i ${extIF} -p tcp -d ${dADDR} --dport ${dPORT0}${ID} -j ACCEPT > /dev/null 2>&1
+
+	echo "[${IP_ACTION}] ${sADDR}${ID}:443 -> ${dADDR}:${dPORT0}${ID}"
+done
+
+if [ "x${IP_ACTION}" == "xadd" ]; then
+	ID=1
+	echo "Now please add the following lines to your dnsmasq configuration, 'config dnsmasq' section (/etc/config/dhcp)"
+	for H in ${HOSTS}; do
+		echo "list address '/${H}/${sADDR}${ID}'"
+		let ID=${ID}+1
+	done
+fi


### PR DESCRIPTION
Предлагаемое решение по сути является костылем :) и требует OpenWRT (или чего-то подобного) со стороны клиента на роутере.

Решение основано на запуске sniproxy на стороне прокси-сервера на отдельных портах (api-global.netflix.com (порт 4431), uiboot.netflix.com (порт 4432), secure.netflix.com (порт 4433)) со статическим форвардингом запросов на сервера netflix.
Со стороны клиентского роутера при это на локальном интерфейсе (чаще всего - это linux-bridge, объединяющий проводные и беспроводные интерфейсы) 3х дополнительных IP-адресов, запросы на 443 порт которых пересылаются на соответствующие порты прокси-сервера.

Кроме того, добавлен скрипт netflix_redirect.sh, который может быть использован для полу-автоматической настройки клиентского роутера для указанных выше редиректов. Запуск скрипта без параметров создает необходимые редиректы, запуск с ключем --delete удаляет все адреса и правила iptables из системы.

По-умолчанию он добавляет IP-адреса 192.168.44.31 (редирект на прокси:4431), 192.168.44.32 (редирект на прокси:4432), 192.168.44.31 (редирект на прокси:4432). Данные настройки могут быть измены в теле скрипта.

В конце своей работы скрипт вывод в консоль строки, которые необходимо добавить в конфиг.файл демона dnsmasq (/etc/config/dhcp). Например:
Now please add the following lines to your dnsmasq configuration, 'config dnsmasq' section (/etc/config/dhcp)
list address '/api-global.netflix.com/192.168.44.31'
list address '/uiboot.netflix.com/192.168.44.32'
list address '/secure.netflix.com/192.168.44.33'
